### PR TITLE
Added info dialog when launching from non-chrome os platforms

### DIFF
--- a/app/mount_error.html
+++ b/app/mount_error.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+</head>
+
+<body>
+
+<h3>We are sorry. This app only works for Chrome OS.</h3>
+
+</body>
+</html>

--- a/app/plugin.js
+++ b/app/plugin.js
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+const chromeOs = "cros";
 
 // Init client.
 var smbfs = new SambaClient();
@@ -152,5 +153,12 @@ document.addEventListener('DOMContentLoaded', function() {
   listenerDiv.addEventListener('load', naclLoaded, true);
 });
 
-listenForFileSystemEvents();
-chrome.app.runtime.onLaunched.addListener(loadForegroundPage);
+chrome.runtime.getPlatformInfo(function(info) {
+  if (info.os === chromeOs) {
+    listenForFileSystemEvents();
+    chrome.app.runtime.onLaunched.addListener(loadForegroundPage);
+  } else {
+    log.warning("** Warning, not running on Chrome OS **");
+    chrome.app.runtime.onLaunched.addListener(loadMountErrorPage);
+  }
+});

--- a/app/window_launchers.js
+++ b/app/window_launchers.js
@@ -36,3 +36,14 @@ function loadLicensePage() {
     frame: {type: 'chrome', color: '#137CD0'}
   });
 }
+
+function loadMountErrorPage() {
+  chrome.app.window.create('mount_error.html', {
+    id: 'mount_error',
+    innerBounds: {width: 640, height: 390, left: 100, top: 100},
+    hidden: false,
+    minWidth: 640,
+    minHeight: 390,
+    frame: {type: 'chrome', color: '#137CD0'}
+  });
+}


### PR DESCRIPTION
For #38.

Waiting on UX mock for the mount error dialog box.